### PR TITLE
refactor chip widgets and data storage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart'; //imports flutter -- most important line of code
 import 'package:provider/provider.dart';
 
-import '../pages/generator.dart';
-import '../pages/auto.dart';
-import '../pages/teleop.dart';
 import '../pages/endgame.dart';
+import '../pages/generator.dart';
+import '../pages/teleop.dart';
+import '../pages/auto.dart';
 
 void main() {
   runApp(const MyApp()); //runs the app
@@ -31,69 +31,37 @@ class MyApp extends StatelessWidget {
   }
 }
 
+enum Piece { none, cone, cube }
+
+// parked only used for endgame's position
+enum Position { none, docked, parked, engaged }
+
+enum StartingPosition { none, red1, red2, red3, blue1, blue2, blue3 }
+
 class MyAppState extends ChangeNotifier {
-  Position position = Position.none;
-  EndgamePosition endgamePosition = EndgamePosition.none;
-  AutoPosition autoPosition = AutoPosition.none;
-  AutoHigh1 autoHigh1 = AutoHigh1.none;
-  AutoHigh2 autoHigh2 = AutoHigh2.none;
-  AutoHigh3 autoHigh3 = AutoHigh3.none;
-  AutoHigh4 autoHigh4 = AutoHigh4.none;
-  AutoHigh5 autoHigh5 = AutoHigh5.none;
-  AutoHigh6 autoHigh6 = AutoHigh6.none;
-  AutoHigh7 autoHigh7 = AutoHigh7.none;
-  AutoHigh8 autoHigh8 = AutoHigh8.none;
-  AutoHigh9 autoHigh9 = AutoHigh9.none;
-  AutoMid1 autoMid1 = AutoMid1.none;
-  AutoMid2 autoMid2 = AutoMid2.none;
-  AutoMid3 autoMid3 = AutoMid3.none;
-  AutoMid4 autoMid4 = AutoMid4.none;
-  AutoMid5 autoMid5 = AutoMid5.none;
-  AutoMid6 autoMid6 = AutoMid6.none;
-  AutoMid7 autoMid7 = AutoMid7.none;
-  AutoMid8 autoMid8 = AutoMid8.none;
-  AutoMid9 autoMid9 = AutoMid9.none;
-  AutoLow1 autoLow1 = AutoLow1.none;
-  AutoLow2 autoLow2 = AutoLow2.none;
-  AutoLow3 autoLow3 = AutoLow3.none;
-  AutoLow4 autoLow4 = AutoLow4.none;
-  AutoLow5 autoLow5 = AutoLow5.none;
-  AutoLow6 autoLow6 = AutoLow6.none;
-  AutoLow7 autoLow7 = AutoLow7.none;
-  AutoLow8 autoLow8 = AutoLow8.none;
-  AutoLow9 autoLow9 = AutoLow9.none;
-  AutoMobility autoMobility = AutoMobility.no;
-  TeleopHigh1 teleopHigh1 = TeleopHigh1.none;
-  TeleopHigh2 teleopHigh2 = TeleopHigh2.none;
-  TeleopHigh3 teleopHigh3 = TeleopHigh3.none;
-  TeleopHigh4 teleopHigh4 = TeleopHigh4.none;
-  TeleopHigh5 teleopHigh5 = TeleopHigh5.none;
-  TeleopHigh6 teleopHigh6 = TeleopHigh6.none;
-  TeleopHigh7 teleopHigh7 = TeleopHigh7.none;
-  TeleopHigh8 teleopHigh8 = TeleopHigh8.none;
-  TeleopHigh9 teleopHigh9 = TeleopHigh9.none;
-  TeleopMid1 teleopMid1 = TeleopMid1.none;
-  TeleopMid2 teleopMid2 = TeleopMid2.none;
-  TeleopMid3 teleopMid3 = TeleopMid3.none;
-  TeleopMid4 teleopMid4 = TeleopMid4.none;
-  TeleopMid5 teleopMid5 = TeleopMid5.none;
-  TeleopMid6 teleopMid6 = TeleopMid6.none;
-  TeleopMid7 teleopMid7 = TeleopMid7.none;
-  TeleopMid8 teleopMid8 = TeleopMid8.none;
-  TeleopMid9 teleopMid9 = TeleopMid9.none;
-  TeleopLow1 teleopLow1 = TeleopLow1.none;
-  TeleopLow2 teleopLow2 = TeleopLow2.none;
-  TeleopLow3 teleopLow3 = TeleopLow3.none;
-  TeleopLow4 teleopLow4 = TeleopLow4.none;
-  TeleopLow5 teleopLow5 = TeleopLow5.none;
-  TeleopLow6 teleopLow6 = TeleopLow6.none;
-  TeleopLow7 teleopLow7 = TeleopLow7.none;
-  TeleopLow8 teleopLow8 = TeleopLow8.none;
-  TeleopLow9 teleopLow9 = TeleopLow9.none;
-  Defence defence = Defence.no;
-  GroundIntake groundIntake = GroundIntake.no;
-  SingleSubstationIntake singleSubstationIntake = SingleSubstationIntake.no;
-  DoubleSubstationIntake doubleSubstationIntake = DoubleSubstationIntake.no;
+  // Generator Page Data
+  final commentController = TextEditingController();
+  final teamController = TextEditingController();
+  StartingPosition startingPosition = StartingPosition.none;
+
+  // Auto Page Data
+  bool autoMobility = false;
+  Position autoPosition = Position.none;
+  List<bool> autoHigh = List.filled(10, false);
+  List<bool> autoMid = List.filled(10, false);
+  List<Piece> autoLow = List.filled(10, Piece.none);
+
+  // Teleop Page Data
+  bool defense = false;
+  bool groundIntake = false;
+  bool singleSubstationIntake = false;
+  bool doubleSubstationIntake = false;
+  List<bool> teleopHigh = List.filled(10, false);
+  List<bool> teleopMid = List.filled(10, false);
+  List<Piece> teleopLow = List.filled(10, Piece.none);
+
+  // Endgame Page Data
+  Position endgamePosition = Position.none;
 }
 
 class MyHomePage extends StatefulWidget {
@@ -111,9 +79,8 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     Widget page;
 
+    // assigns the relevant page for the selected index
     switch (selectedIndex) {
-      //allows the page to change
-      //placeholders should be replaced with the widgets for the appropriate pages
       case 0:
         page = const GeneratorPage();
         break;
@@ -152,11 +119,8 @@ class _MyHomePageState extends State<MyHomePage> {
                         label: Text('Endgame')),
                   ],
                   selectedIndex: selectedIndex,
-                  onDestinationSelected: (value) {
-                    setState(() {
-                      selectedIndex = value;
-                    });
-                  },
+                  onDestinationSelected: (value) =>
+                      setState(() => selectedIndex = value),
                 ),
               ),
               Expanded(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,6 +62,30 @@ class MyAppState extends ChangeNotifier {
 
   // Endgame Page Data
   Position endgamePosition = Position.none;
+
+  // Resets All Data
+  // The function is here to easily check that it includes all the variables
+  void reset() {
+    commentController.clear();
+    teamController.clear();
+    startingPosition = StartingPosition.none;
+
+    autoMobility = false;
+    autoPosition = Position.none;
+    autoHigh = List.filled(10, false);
+    autoMid = List.filled(10, false);
+    autoLow = List.filled(10, Piece.none);
+
+    defense = false;
+    groundIntake = false;
+    singleSubstationIntake = false;
+    doubleSubstationIntake = false;
+    teleopHigh = List.filled(10, false);
+    teleopMid = List.filled(10, false);
+    teleopLow = List.filled(10, Piece.none);
+
+    endgamePosition = Position.none;
+  }
 }
 
 class MyHomePage extends StatefulWidget {

--- a/lib/pages/auto.dart
+++ b/lib/pages/auto.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../main.dart';
+import '../widgets/enum_chip.dart';
 import '../widgets/toggle_chip.dart';
 import '../widgets/scoring_legend.dart';
 
@@ -12,665 +13,102 @@ class AutoPage extends StatefulWidget {
   State<AutoPage> createState() => _AutoPageState();
 }
 
-enum AutoPosition { none, docked, engaged }
-
-enum AutoHigh1 { none, cone }
-
-enum AutoHigh2 { none, cube }
-
-enum AutoHigh3 { none, cone }
-
-enum AutoHigh4 { none, cone }
-
-enum AutoHigh5 { none, cube }
-
-enum AutoHigh6 { none, cone }
-
-enum AutoHigh7 { none, cone }
-
-enum AutoHigh8 { none, cube }
-
-enum AutoHigh9 { none, cone }
-
-enum AutoMid1 { none, cone }
-
-enum AutoMid2 { none, cube }
-
-enum AutoMid3 { none, cone }
-
-enum AutoMid4 { none, cone }
-
-enum AutoMid5 { none, cube }
-
-enum AutoMid6 { none, cone }
-
-enum AutoMid7 { none, cone }
-
-enum AutoMid8 { none, cube }
-
-enum AutoMid9 { none, cone }
-
-enum AutoLow1 { none, cone, cube }
-
-enum AutoLow2 { none, cone, cube }
-
-enum AutoLow3 { none, cone, cube }
-
-enum AutoLow4 { none, cone, cube }
-
-enum AutoLow5 { none, cone, cube }
-
-enum AutoLow6 { none, cone, cube }
-
-enum AutoLow7 { none, cone, cube }
-
-enum AutoLow8 { none, cone, cube }
-
-enum AutoLow9 { none, cone, cube }
-
-enum AutoMobility { no, yes }
-
 class _AutoPageState extends State<AutoPage> {
   @override
   Widget build(BuildContext context) {
     var appState = context.watch<MyAppState>();
 
-    void updateAutoPosition(AutoPosition value) {
-      setState(() {
-        appState.autoPosition = value;
-      });
-    }
-
-    void updateAutoMobility(AutoMobility value) {
-      setState(() {
-        if (appState.autoMobility == value) {
-          appState.autoMobility = AutoMobility.no;
-        } else {
-          appState.autoMobility = value;
-        }
-      });
-    }
-
-    void updateAutoHigh1(AutoHigh1 value) {
-      setState(() {
-        if (appState.autoHigh1 == value) {
-          appState.autoHigh1 = AutoHigh1.none;
-        } else {
-          appState.autoHigh1 = value;
-        }
-      });
-    }
-
-    void updateAutoHigh2(AutoHigh2 value) {
-      setState(() {
-        if (appState.autoHigh2 == value) {
-          appState.autoHigh2 = AutoHigh2.none;
-        } else {
-          appState.autoHigh2 = value;
-        }
-      });
-    }
-
-    void updateAutoHigh3(AutoHigh3 value) {
-      setState(() {
-        if (appState.autoHigh3 == value) {
-          appState.autoHigh3 = AutoHigh3.none;
-        } else {
-          appState.autoHigh3 = value;
-        }
-      });
-    }
-
-    void updateAutoHigh4(AutoHigh4 value) {
-      setState(() {
-        if (appState.autoHigh4 == value) {
-          appState.autoHigh4 = AutoHigh4.none;
-        } else {
-          appState.autoHigh4 = value;
-        }
-      });
-    }
-
-    void updateAutoHigh5(AutoHigh5 value) {
-      setState(() {
-        if (appState.autoHigh5 == value) {
-          appState.autoHigh5 = AutoHigh5.none;
-        } else {
-          appState.autoHigh5 = value;
-        }
-      });
-    }
-
-    void updateAutoHigh6(AutoHigh6 value) {
-      setState(() {
-        if (appState.autoHigh6 == value) {
-          appState.autoHigh6 = AutoHigh6.none;
-        } else {
-          appState.autoHigh6 = value;
-        }
-      });
-    }
-
-    void updateAutoHigh7(AutoHigh7 value) {
-      setState(() {
-        if (appState.autoHigh7 == value) {
-          appState.autoHigh7 = AutoHigh7.none;
-        } else {
-          appState.autoHigh7 = value;
-        }
-      });
-    }
-
-    void updateAutoHigh8(AutoHigh8 value) {
-      setState(() {
-        if (appState.autoHigh8 == value) {
-          appState.autoHigh8 = AutoHigh8.none;
-        } else {
-          appState.autoHigh8 = value;
-        }
-      });
-    }
-
-    void updateAutoHigh9(AutoHigh9 value) {
-      setState(() {
-        if (appState.autoHigh9 == value) {
-          appState.autoHigh9 = AutoHigh9.none;
-        } else {
-          appState.autoHigh9 = value;
-        }
-      });
-    }
-
-    void updateAutoMid1(AutoMid1 value) {
-      setState(() {
-        if (appState.autoMid1 == value) {
-          appState.autoMid1 = AutoMid1.none;
-        } else {
-          appState.autoMid1 = value;
-        }
-      });
-    }
-
-    void updateAutoMid2(AutoMid2 value) {
-      setState(() {
-        if (appState.autoMid2 == value) {
-          appState.autoMid2 = AutoMid2.none;
-        } else {
-          appState.autoMid2 = value;
-        }
-      });
-    }
-
-    void updateAutoMid3(AutoMid3 value) {
-      setState(() {
-        if (appState.autoMid3 == value) {
-          appState.autoMid3 = AutoMid3.none;
-        } else {
-          appState.autoMid3 = value;
-        }
-      });
-    }
-
-    void updateAutoMid4(AutoMid4 value) {
-      setState(() {
-        if (appState.autoMid4 == value) {
-          appState.autoMid4 = AutoMid4.none;
-        } else {
-          appState.autoMid4 = value;
-        }
-      });
-    }
-
-    void updateAutoMid5(AutoMid5 value) {
-      setState(() {
-        if (appState.autoMid5 == value) {
-          appState.autoMid5 = AutoMid5.none;
-        } else {
-          appState.autoMid5 = value;
-        }
-      });
-    }
-
-    void updateAutoMid6(AutoMid6 value) {
-      setState(() {
-        if (appState.autoMid6 == value) {
-          appState.autoMid6 = AutoMid6.none;
-        } else {
-          appState.autoMid6 = value;
-        }
-      });
-    }
-
-    void updateAutoMid7(AutoMid7 value) {
-      setState(() {
-        if (appState.autoMid7 == value) {
-          appState.autoMid7 = AutoMid7.none;
-        } else {
-          appState.autoMid7 = value;
-        }
-      });
-    }
-
-    void updateAutoMid8(AutoMid8 value) {
-      setState(() {
-        if (appState.autoMid8 == value) {
-          appState.autoMid8 = AutoMid8.none;
-        } else {
-          appState.autoMid8 = value;
-        }
-      });
-    }
-
-    void updateAutoMid9(AutoMid9 value) {
-      setState(() {
-        if (appState.autoMid9 == value) {
-          appState.autoMid9 = AutoMid9.none;
-        } else {
-          appState.autoMid9 = value;
-        }
-      });
-    }
-
-    void updateAutoLow1(AutoLow1 value) {
-      setState(() {
-        if (appState.autoLow1 == value) {
-          appState.autoLow1 = AutoLow1.none;
-        } else {
-          appState.autoLow1 = value;
-        }
-      });
-    }
-
-    void updateAutoLow2(AutoLow2 value) {
-      setState(() {
-        if (appState.autoLow2 == value) {
-          appState.autoLow2 = AutoLow2.none;
-        } else {
-          appState.autoLow2 = value;
-        }
-      });
-    }
-
-    void updateAutoLow3(AutoLow3 value) {
-      setState(() {
-        if (appState.autoLow3 == value) {
-          appState.autoLow3 = AutoLow3.none;
-        } else {
-          appState.autoLow3 = value;
-        }
-      });
-    }
-
-    void updateAutoLow4(AutoLow4 value) {
-      setState(() {
-        if (appState.autoLow4 == value) {
-          appState.autoLow4 = AutoLow4.none;
-        } else {
-          appState.autoLow4 = value;
-        }
-      });
-    }
-
-    void updateAutoLow5(AutoLow5 value) {
-      setState(() {
-        if (appState.autoLow5 == value) {
-          appState.autoLow5 = AutoLow5.none;
-        } else {
-          appState.autoLow5 = value;
-        }
-      });
-    }
-
-    void updateAutoLow6(AutoLow6 value) {
-      setState(() {
-        if (appState.autoLow6 == value) {
-          appState.autoLow6 = AutoLow6.none;
-        } else {
-          appState.autoLow6 = value;
-        }
-      });
-    }
-
-    void updateAutoLow7(AutoLow7 value) {
-      setState(() {
-        if (appState.autoLow7 == value) {
-          appState.autoLow7 = AutoLow7.none;
-        } else {
-          appState.autoLow7 = value;
-        }
-      });
-    }
-
-    void updateAutoLow8(AutoLow8 value) {
-      setState(() {
-        if (appState.autoLow8 == value) {
-          appState.autoLow8 = AutoLow8.none;
-        } else {
-          appState.autoLow8 = value;
-        }
-      });
-    }
-
-    void updateAutoLow9(AutoLow9 value) {
-      setState(() {
-        if (appState.autoLow9 == value) {
-          appState.autoLow9 = AutoLow9.none;
-        } else {
-          appState.autoLow9 = value;
-        }
-      });
+    void updatePosition(value) {
+      setState(() => appState.autoPosition = value);
     }
 
     return Center(
-        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: <
-            Widget>[
-      ToggleChip(
+        child: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        CircleToggleChip(
           text: "Mobility",
-          onPressed: updateAutoMobility,
-          value: AutoMobility.yes,
-          selection: appState.autoMobility,
-          icon1: Icons.circle,
-          icon2: Icons.circle_outlined),
-      const SizedBox(height: 8),
-      const Text("Chargepad:"),
-      Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-        ToggleChip(
-            text: "None",
-            onPressed: updateAutoPosition,
-            value: AutoPosition.none,
-            selection: appState.autoPosition,
-            icon1: Icons.circle,
-            icon2: Icons.circle_outlined),
-        ToggleChip(
-            text: "Docked",
-            onPressed: updateAutoPosition,
-            value: AutoPosition.docked,
-            selection: appState.autoPosition,
-            icon1: Icons.circle,
-            icon2: Icons.circle_outlined),
-        ToggleChip(
-            text: "Engaged",
-            onPressed: updateAutoPosition,
-            value: AutoPosition.engaged,
-            selection: appState.autoPosition,
-            icon1: Icons.circle,
-            icon2: Icons.circle_outlined),
-      ]),
-      const SizedBox(height: 8),
-      const ScoringLegend(),
-      const Text("Auto Pieces Scored:"),
-      Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-        Column(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoHigh1,
-              value: AutoHigh1.cone,
-              selection: appState.autoHigh1,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoMid1,
-              value: AutoMid1.cone,
-              selection: appState.autoMid1,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow1,
-              value: AutoLow1.cone,
-              selection: appState.autoLow1,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow1,
-              value: AutoLow1.cube,
-              selection: appState.autoLow1,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-        ]),
-        Column(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoHigh2,
-              value: AutoHigh2.cube,
-              selection: appState.autoHigh2,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoMid2,
-              value: AutoMid2.cube,
-              selection: appState.autoMid2,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow2,
-              value: AutoLow2.cone,
-              selection: appState.autoLow2,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow2,
-              value: AutoLow2.cube,
-              selection: appState.autoLow2,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-        ]),
-        Column(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoHigh3,
-              value: AutoHigh3.cone,
-              selection: appState.autoHigh3,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoMid3,
-              value: AutoMid3.cone,
-              selection: appState.autoMid3,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow3,
-              value: AutoLow3.cone,
-              selection: appState.autoLow3,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow3,
-              value: AutoLow3.cube,
-              selection: appState.autoLow3,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-        ]),
-        Column(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoHigh4,
-              value: AutoHigh4.cone,
-              selection: appState.autoHigh4,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoMid4,
-              value: AutoMid4.cone,
-              selection: appState.autoMid4,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow4,
-              value: AutoLow4.cone,
-              selection: appState.autoLow4,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow4,
-              value: AutoLow4.cube,
-              selection: appState.autoLow4,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-        ]),
-        Column(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoHigh5,
-              value: AutoHigh5.cube,
-              selection: appState.autoHigh5,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoMid5,
-              value: AutoMid5.cube,
-              selection: appState.autoMid5,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow5,
-              value: AutoLow5.cone,
-              selection: appState.autoLow5,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow5,
-              value: AutoLow5.cube,
-              selection: appState.autoLow5,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-        ]),
-        Column(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoHigh6,
-              value: AutoHigh6.cone,
-              selection: appState.autoHigh6,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoMid6,
-              value: AutoMid6.cone,
-              selection: appState.autoMid6,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow6,
-              value: AutoLow6.cone,
-              selection: appState.autoLow6,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow6,
-              value: AutoLow6.cube,
-              selection: appState.autoLow6,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-        ]),
-        Column(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoHigh7,
-              value: AutoHigh7.cone,
-              selection: appState.autoHigh7,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoMid7,
-              value: AutoMid7.cone,
-              selection: appState.autoMid7,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow7,
-              value: AutoLow7.cone,
-              selection: appState.autoLow7,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow7,
-              value: AutoLow7.cube,
-              selection: appState.autoLow7,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-        ]),
-        Column(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoHigh8,
-              value: AutoHigh8.cube,
-              selection: appState.autoHigh8,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoMid8,
-              value: AutoMid8.cube,
-              selection: appState.autoMid8,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow8,
-              value: AutoLow8.cone,
-              selection: appState.autoLow8,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow8,
-              value: AutoLow8.cube,
-              selection: appState.autoLow8,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-        ]),
-        Column(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoHigh9,
-              value: AutoHigh9.cone,
-              selection: appState.autoHigh9,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoMid9,
-              value: AutoMid9.cone,
-              selection: appState.autoMid9,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow9,
-              value: AutoLow9.cone,
-              selection: appState.autoLow9,
-              icon1: Icons.adobe,
-              icon2: Icons.change_history),
-          ToggleChip(
-              text: "",
-              onPressed: updateAutoLow9,
-              value: AutoLow9.cube,
-              selection: appState.autoLow9,
-              icon1: Icons.square,
-              icon2: Icons.square_outlined),
-        ]),
-      ])
-    ]));
+          onPressed: (value) => setState(() => appState.autoMobility = value),
+          isSelected: appState.autoMobility,
+        ),
+        const SizedBox(height: 8),
+        const Text("Chargepad:"),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            CircleEnumChip(
+              text: "None",
+              onPressed: updatePosition,
+              value: Position.none,
+              selection: appState.autoPosition,
+            ),
+            CircleEnumChip(
+              text: "Docked",
+              onPressed: updatePosition,
+              value: Position.docked,
+              selection: appState.autoPosition,
+            ),
+            CircleEnumChip(
+              text: "Engaged",
+              onPressed: updatePosition,
+              value: Position.engaged,
+              selection: appState.autoPosition,
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        const ScoringLegend(),
+        const Text("Auto Pieces Scored:"),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: List.generate(9, (i) => i).map((i) {
+            void updateHigh(value) {
+              setState(() => appState.autoHigh[i] = value);
+            }
+
+            void updateMid(value) {
+              setState(() => appState.autoMid[i] = value);
+            }
+
+            void updateLow(value) {
+              setState(() => appState.autoLow[i] = value);
+            }
+
+            return Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: i % 3 != 1
+                  ? [
+                      ConeToggleChip(
+                        onPressed: updateHigh,
+                        isSelected: appState.autoHigh[i],
+                      ),
+                      ConeToggleChip(
+                        onPressed: updateMid,
+                        isSelected: appState.autoMid[i],
+                      ),
+                      HybridEnumChip(
+                        onPressed: updateLow,
+                        selection: appState.autoLow[i],
+                      )
+                    ]
+                  : [
+                      CubeToggleChip(
+                        onPressed: updateHigh,
+                        isSelected: appState.autoHigh[i],
+                      ),
+                      CubeToggleChip(
+                        onPressed: updateMid,
+                        isSelected: appState.autoMid[i],
+                      ),
+                      HybridEnumChip(
+                        onPressed: updateLow,
+                        selection: appState.autoLow[i],
+                      )
+                    ],
+            );
+          }).toList(),
+        ),
+      ],
+    ));
   }
 }

--- a/lib/pages/auto.dart
+++ b/lib/pages/auto.dart
@@ -26,7 +26,7 @@ class _AutoPageState extends State<AutoPage> {
         child: Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
-        CircleToggleChip(
+        ToggleChip(
           text: "Mobility",
           onPressed: (value) => setState(() => appState.autoMobility = value),
           isSelected: appState.autoMobility,
@@ -36,19 +36,19 @@ class _AutoPageState extends State<AutoPage> {
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            CircleEnumChip(
+            EnumChip(
               text: "None",
               onPressed: updatePosition,
               value: Position.none,
               selection: appState.autoPosition,
             ),
-            CircleEnumChip(
+            EnumChip(
               text: "Docked",
               onPressed: updatePosition,
               value: Position.docked,
               selection: appState.autoPosition,
             ),
-            CircleEnumChip(
+            EnumChip(
               text: "Engaged",
               onPressed: updatePosition,
               value: Position.engaged,
@@ -76,35 +76,31 @@ class _AutoPageState extends State<AutoPage> {
 
             return Column(
               mainAxisAlignment: MainAxisAlignment.center,
-              children: i % 3 != 1
-                  ? [
-                      ConeToggleChip(
+              // ToggleChip type depends on column number
+              children: [
+                i % 3 != 1
+                    ? ConeChip(
+                        onPressed: updateHigh,
+                        isSelected: appState.autoHigh[i],
+                      )
+                    : CubeChip(
                         onPressed: updateHigh,
                         isSelected: appState.autoHigh[i],
                       ),
-                      ConeToggleChip(
+                i % 3 != 1
+                    ? ConeChip(
+                        onPressed: updateMid,
+                        isSelected: appState.autoMid[i],
+                      )
+                    : CubeChip(
                         onPressed: updateMid,
                         isSelected: appState.autoMid[i],
                       ),
-                      HybridEnumChip(
-                        onPressed: updateLow,
-                        selection: appState.autoLow[i],
-                      )
-                    ]
-                  : [
-                      CubeToggleChip(
-                        onPressed: updateHigh,
-                        isSelected: appState.autoHigh[i],
-                      ),
-                      CubeToggleChip(
-                        onPressed: updateMid,
-                        isSelected: appState.autoMid[i],
-                      ),
-                      HybridEnumChip(
-                        onPressed: updateLow,
-                        selection: appState.autoLow[i],
-                      )
-                    ],
+                HybridChip(
+                  onPressed: updateLow,
+                  selection: appState.autoLow[i],
+                )
+              ],
             );
           }).toList(),
         ),

--- a/lib/pages/endgame.dart
+++ b/lib/pages/endgame.dart
@@ -17,9 +17,7 @@ class _EndgamePageState extends State<EndgamePage> {
     var appState = context.watch<MyAppState>();
 
     void updatePosition(Position value) {
-      setState(() {
-        appState.endgamePosition = value;
-      });
+      setState(() => appState.endgamePosition = value);
     }
 
     return Center(
@@ -28,25 +26,25 @@ class _EndgamePageState extends State<EndgamePage> {
       children: <Widget>[
         const Text('Robot endgame position:'),
         const SizedBox(height: 8),
-        CircleEnumChip(
+        EnumChip(
           text: "None",
           onPressed: updatePosition,
           value: Position.none,
           selection: appState.endgamePosition,
         ),
-        CircleEnumChip(
+        EnumChip(
           text: "Parked",
           onPressed: updatePosition,
           value: Position.parked,
           selection: appState.endgamePosition,
         ),
-        CircleEnumChip(
+        EnumChip(
           text: "Docked",
           onPressed: updatePosition,
           value: Position.docked,
           selection: appState.endgamePosition,
         ),
-        CircleEnumChip(
+        EnumChip(
           text: "Engaged",
           onPressed: updatePosition,
           value: Position.engaged,

--- a/lib/pages/endgame.dart
+++ b/lib/pages/endgame.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../main.dart';
-import '../widgets/toggle_chip.dart';
+import '../widgets/enum_chip.dart';
 
 class EndgamePage extends StatefulWidget {
   const EndgamePage({super.key});
@@ -11,14 +11,12 @@ class EndgamePage extends StatefulWidget {
   State<EndgamePage> createState() => _EndgamePageState();
 }
 
-enum EndgamePosition { none, docked, parked, engaged }
-
 class _EndgamePageState extends State<EndgamePage> {
   @override
   Widget build(BuildContext context) {
     var appState = context.watch<MyAppState>();
 
-    void updateEndgamePosition(EndgamePosition value) {
+    void updatePosition(Position value) {
       setState(() {
         appState.endgamePosition = value;
       });
@@ -26,40 +24,35 @@ class _EndgamePageState extends State<EndgamePage> {
 
     return Center(
         child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-          const Padding(
-            padding: EdgeInsets.all(8.0),
-            child: Text('Robot endgame position:'),
-          ),
-          ToggleChip(
-              text: "None",
-              onPressed: updateEndgamePosition,
-              value: EndgamePosition.none,
-              selection: appState.endgamePosition,
-              icon1: Icons.circle,
-              icon2: Icons.circle_outlined),
-          ToggleChip(
-              text: "Parked",
-              onPressed: updateEndgamePosition,
-              value: EndgamePosition.parked,
-              selection: appState.endgamePosition,
-              icon1: Icons.circle,
-              icon2: Icons.circle_outlined),
-          ToggleChip(
-              text: "Docked",
-              onPressed: updateEndgamePosition,
-              value: EndgamePosition.docked,
-              selection: appState.endgamePosition,
-              icon1: Icons.circle,
-              icon2: Icons.circle_outlined),
-          ToggleChip(
-              text: "Engaged",
-              onPressed: updateEndgamePosition,
-              value: EndgamePosition.engaged,
-              selection: appState.endgamePosition,
-              icon1: Icons.circle,
-              icon2: Icons.circle_outlined),
-        ]));
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        const Text('Robot endgame position:'),
+        const SizedBox(height: 8),
+        CircleEnumChip(
+          text: "None",
+          onPressed: updatePosition,
+          value: Position.none,
+          selection: appState.endgamePosition,
+        ),
+        CircleEnumChip(
+          text: "Parked",
+          onPressed: updatePosition,
+          value: Position.parked,
+          selection: appState.endgamePosition,
+        ),
+        CircleEnumChip(
+          text: "Docked",
+          onPressed: updatePosition,
+          value: Position.docked,
+          selection: appState.endgamePosition,
+        ),
+        CircleEnumChip(
+          text: "Engaged",
+          onPressed: updatePosition,
+          value: Position.engaged,
+          selection: appState.endgamePosition,
+        ),
+      ],
+    ));
   }
 }

--- a/lib/pages/generator.dart
+++ b/lib/pages/generator.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../main.dart';
-import '../widgets/toggle_chip.dart';
+import '../widgets/enum_chip.dart';
 
 class GeneratorPage extends StatefulWidget {
   const GeneratorPage({super.key});
@@ -12,146 +11,111 @@ class GeneratorPage extends StatefulWidget {
   State<GeneratorPage> createState() => GeneratorPageState();
 }
 
-enum Position { none, red1, red2, red3, blue1, blue2, blue3 }
-
 class GeneratorPageState extends State<GeneratorPage> {
-  final _commentController = TextEditingController();
-  final _teamController = TextEditingController();
-
-  Future _getData() async {
-    final preferences = await SharedPreferences.getInstance();
-    setState(() {
-      _commentController.text = preferences.getString('Comments') ?? '';
-      _teamController.text = preferences.getString('Team number') ?? '';
-    });
-  }
-
-  Future _saveData() async {
-    final preferences = await SharedPreferences.getInstance();
-    preferences.setString('Comments', _commentController.text);
-    preferences.setString('Team number', _teamController.text);
-  }
-
-  @override
-  void initState() {
-    _getData();
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _saveData();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
     //allows the home page widget to use variables from the app state
     var appState = context.watch<MyAppState>();
 
-    void updatePosition(Position value) {
+    void updatePosition(StartingPosition value) {
       setState(() {
-        appState.position = value;
+        appState.startingPosition = value;
       });
     }
 
     return Center(
         child: Column(
-            //centres the column in the GeneratorPage widget
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-          const Padding(
-            //gives the text more space
-            padding: EdgeInsets.all(8.0),
-            child: Text('Comments:'),
+      //centres the column in the GeneratorPage widget
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        const Padding(
+          //gives the text more space
+          padding: EdgeInsets.all(8.0),
+          child: Text('Comments:'),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: SizedBox(
+            width: 300,
+            child: TextFormField(
+              controller: appState.commentController,
+            ),
           ),
-          Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: SizedBox(
-                width: 300,
-                child: TextFormField(
-                  controller: _commentController,
-                ),
-              )), //allows the user to type input
-          const SizedBox(height: 8),
-          const Padding(
-            padding: EdgeInsets.all(8.0),
-            child: Text('Team number:'),
-          ),
-          Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: SizedBox(
-                width: 300,
-                child: TextFormField(
-                  controller: _teamController,
-                ),
-              )),
-          const SizedBox(height: 8),
-          const Padding(
-            padding: EdgeInsets.all(8.0),
-            child: Text('Robot position:'),
-          ),
-          //creates buttons to select the robot's position
+        ), //allows the user to type input
+        const SizedBox(height: 8),
+        const Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Text('Team number:'),
+        ),
+        Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: SizedBox(
+              width: 300,
+              child: TextFormField(
+                controller: appState.teamController,
+              ),
+            )),
+        const SizedBox(height: 8),
+        const Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Text('Robot position:'),
+        ),
+        //creates buttons to select the robot's position
 
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              ToggleChip(
-                  text: "Red 1",
-                  onPressed: updatePosition,
-                  value: Position.red1,
-                  selection: appState.position,
-                  icon1: Icons.circle,
-                  icon2: Icons.circle_outlined),
-              ToggleChip(
-                  text: "Red 2",
-                  onPressed: updatePosition,
-                  value: Position.red2,
-                  selection: appState.position,
-                  icon1: Icons.circle,
-                  icon2: Icons.circle_outlined),
-              ToggleChip(
-                  text: "Red 3",
-                  onPressed: updatePosition,
-                  value: Position.red3,
-                  selection: appState.position,
-                  icon1: Icons.circle,
-                  icon2: Icons.circle_outlined),
-            ],
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              ToggleChip(
-                  text: "Blue 1",
-                  onPressed: updatePosition,
-                  value: Position.blue1,
-                  selection: appState.position,
-                  icon1: Icons.circle,
-                  icon2: Icons.circle_outlined),
-              ToggleChip(
-                  text: "Blue 2",
-                  onPressed: updatePosition,
-                  value: Position.blue2,
-                  selection: appState.position,
-                  icon1: Icons.circle,
-                  icon2: Icons.circle_outlined),
-              ToggleChip(
-                  text: "Blue 3",
-                  onPressed: updatePosition,
-                  value: Position.blue3,
-                  selection: appState.position,
-                  icon1: Icons.circle,
-                  icon2: Icons.circle_outlined),
-            ],
-          ),
-          Padding(
-            padding: const EdgeInsets.all(5.0),
-            child: ElevatedButton(
-                onPressed: () {},
-                child: const Text(
-                    "Save")), //adds a button to save the data, currently not functional
-          )
-        ]));
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            CircleEnumChip(
+              text: "Red 1",
+              onPressed: updatePosition,
+              value: StartingPosition.red1,
+              selection: appState.startingPosition,
+            ),
+            CircleEnumChip(
+              text: "Red 2",
+              onPressed: updatePosition,
+              value: StartingPosition.red2,
+              selection: appState.startingPosition,
+            ),
+            CircleEnumChip(
+              text: "Red 3",
+              onPressed: updatePosition,
+              value: StartingPosition.red3,
+              selection: appState.startingPosition,
+            ),
+          ],
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            CircleEnumChip(
+              text: "Blue 1",
+              onPressed: updatePosition,
+              value: StartingPosition.blue1,
+              selection: appState.startingPosition,
+            ),
+            CircleEnumChip(
+              text: "Blue 2",
+              onPressed: updatePosition,
+              value: StartingPosition.blue2,
+              selection: appState.startingPosition,
+            ),
+            CircleEnumChip(
+              text: "Blue 3",
+              onPressed: updatePosition,
+              value: StartingPosition.blue3,
+              selection: appState.startingPosition,
+            ),
+          ],
+        ),
+        Padding(
+          padding: const EdgeInsets.all(5.0),
+          child: ElevatedButton(
+            onPressed: () {},
+            child: const Text("Save"),
+          ), //adds a button to save the data, currently not functional
+        )
+      ],
+    ));
   }
 }

--- a/lib/pages/generator.dart
+++ b/lib/pages/generator.dart
@@ -18,104 +18,91 @@ class GeneratorPageState extends State<GeneratorPage> {
     var appState = context.watch<MyAppState>();
 
     void updatePosition(StartingPosition value) {
-      setState(() {
-        appState.startingPosition = value;
-      });
+      setState(() => appState.startingPosition = value);
     }
 
     return Center(
-        child: Column(
-      //centres the column in the GeneratorPage widget
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        const Padding(
-          //gives the text more space
-          padding: EdgeInsets.all(8.0),
-          child: Text('Comments:'),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: SizedBox(
+      child: Column(
+        //centres the column in the GeneratorPage widget
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          const Text('Comments'),
+          SizedBox(
             width: 300,
-            child: TextFormField(
-              controller: appState.commentController,
+            child: TextFormField(controller: appState.commentController),
+          ), //allows the user to type input
+          const SizedBox(height: 30),
+          const Text('Team Number'),
+          SizedBox(
+            width: 70,
+            child: TextFormField(controller: appState.teamController),
+          ),
+          const SizedBox(height: 30),
+          const Text('Robot Position'),
+          const SizedBox(height: 10),
+          // Starting Position Buttons
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              EnumChip(
+                text: "Red 1",
+                onPressed: updatePosition,
+                value: StartingPosition.red1,
+                selection: appState.startingPosition,
+              ),
+              EnumChip(
+                text: "Red 2",
+                onPressed: updatePosition,
+                value: StartingPosition.red2,
+                selection: appState.startingPosition,
+              ),
+              EnumChip(
+                text: "Red 3",
+                onPressed: updatePosition,
+                value: StartingPosition.red3,
+                selection: appState.startingPosition,
+              ),
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              EnumChip(
+                text: "Blue 1",
+                onPressed: updatePosition,
+                value: StartingPosition.blue1,
+                selection: appState.startingPosition,
+              ),
+              EnumChip(
+                text: "Blue 2",
+                onPressed: updatePosition,
+                value: StartingPosition.blue2,
+                selection: appState.startingPosition,
+              ),
+              EnumChip(
+                text: "Blue 3",
+                onPressed: updatePosition,
+                value: StartingPosition.blue3,
+                selection: appState.startingPosition,
+              ),
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.all(5.0),
+            child: ElevatedButton(
+              onPressed: () {},
+              child: const Text("Save"),
+            ), //adds a button to save the data, currently not functional
+          ),
+          Padding(
+            padding: const EdgeInsets.all(5.0),
+            child: ElevatedButton(
+              onPressed: () => setState(appState.reset),
+              child: const Text("Reset"),
             ),
           ),
-        ), //allows the user to type input
-        const SizedBox(height: 8),
-        const Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Text('Team number:'),
-        ),
-        Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: SizedBox(
-              width: 300,
-              child: TextFormField(
-                controller: appState.teamController,
-              ),
-            )),
-        const SizedBox(height: 8),
-        const Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Text('Robot position:'),
-        ),
-        //creates buttons to select the robot's position
-
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CircleEnumChip(
-              text: "Red 1",
-              onPressed: updatePosition,
-              value: StartingPosition.red1,
-              selection: appState.startingPosition,
-            ),
-            CircleEnumChip(
-              text: "Red 2",
-              onPressed: updatePosition,
-              value: StartingPosition.red2,
-              selection: appState.startingPosition,
-            ),
-            CircleEnumChip(
-              text: "Red 3",
-              onPressed: updatePosition,
-              value: StartingPosition.red3,
-              selection: appState.startingPosition,
-            ),
-          ],
-        ),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CircleEnumChip(
-              text: "Blue 1",
-              onPressed: updatePosition,
-              value: StartingPosition.blue1,
-              selection: appState.startingPosition,
-            ),
-            CircleEnumChip(
-              text: "Blue 2",
-              onPressed: updatePosition,
-              value: StartingPosition.blue2,
-              selection: appState.startingPosition,
-            ),
-            CircleEnumChip(
-              text: "Blue 3",
-              onPressed: updatePosition,
-              value: StartingPosition.blue3,
-              selection: appState.startingPosition,
-            ),
-          ],
-        ),
-        Padding(
-          padding: const EdgeInsets.all(5.0),
-          child: ElevatedButton(
-            onPressed: () {},
-            child: const Text("Save"),
-          ), //adds a button to save the data, currently not functional
-        )
-      ],
-    ));
+        ],
+      ),
+    );
   }
 }

--- a/lib/pages/teleop.dart
+++ b/lib/pages/teleop.dart
@@ -19,42 +19,43 @@ class _TeleopPageState extends State<TeleopPage> {
     var appState = context.watch<MyAppState>();
 
     return Center(
-        child: Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        CircleToggleChip(
-          text: "Defence",
-          onPressed: (value) => setState(() => appState.defense = value),
-          isSelected: appState.defense,
-        ),
-        const SizedBox(height: 8),
-        const Text("Robot intake position:"),
-        Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-          CircleToggleChip(
-            text: "Ground",
-            onPressed: (value) => setState(() => appState.groundIntake = value),
-            isSelected: appState.groundIntake,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          ToggleChip(
+            text: "Defence",
+            onPressed: (value) => setState(() => appState.defense = value),
+            isSelected: appState.defense,
           ),
-          CircleToggleChip(
-            text: "Single substation",
-            onPressed: (value) =>
-                setState(() => appState.singleSubstationIntake = value),
-            isSelected: appState.singleSubstationIntake,
-          ),
-          CircleToggleChip(
-            text: "Double substation",
-            onPressed: (value) =>
-                setState(() => appState.doubleSubstationIntake = value),
-            isSelected: appState.doubleSubstationIntake,
-          ),
-        ]),
-        const SizedBox(height: 8),
-        const ScoringLegend(),
-        const Text("Teleop Pieces Scored:"),
-        Row(
+          const SizedBox(height: 8),
+          const Text("Robot intake position:"),
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
+            ToggleChip(
+              text: "Ground",
+              onPressed: (value) =>
+                  setState(() => appState.groundIntake = value),
+              isSelected: appState.groundIntake,
+            ),
+            ToggleChip(
+              text: "Single substation",
+              onPressed: (value) =>
+                  setState(() => appState.singleSubstationIntake = value),
+              isSelected: appState.singleSubstationIntake,
+            ),
+            ToggleChip(
+              text: "Double substation",
+              onPressed: (value) =>
+                  setState(() => appState.doubleSubstationIntake = value),
+              isSelected: appState.doubleSubstationIntake,
+            ),
+          ]),
+          const SizedBox(height: 8),
+          const ScoringLegend(),
+          const Text("Teleop Pieces Scored:"),
+          Row(
             mainAxisAlignment: MainAxisAlignment.center,
             // acts like another build function, but for each column
-            children: List.generate(9, (i) => i).map((i) {
+            children: List.generate(9, (i) {
               void updateHigh(value) {
                 setState(() => appState.teleopHigh[i] = value);
               }
@@ -68,39 +69,37 @@ class _TeleopPageState extends State<TeleopPage> {
               }
 
               return Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  // ToggleChip type depends on column number
-                  children: i % 3 != 1
-                      ? [
-                          ConeToggleChip(
-                            onPressed: updateHigh,
-                            isSelected: appState.teleopHigh[i],
-                          ),
-                          ConeToggleChip(
-                            onPressed: updateMid,
-                            isSelected: appState.teleopMid[i],
-                          ),
-                          HybridEnumChip(
-                            onPressed: updateLow,
-                            selection: appState.teleopLow[i],
-                          )
-                        ]
-                      : [
-                          CubeToggleChip(
-                            onPressed: updateHigh,
-                            isSelected: appState.teleopHigh[i],
-                          ),
-                          CubeToggleChip(
-                            onPressed: updateMid,
-                            isSelected: appState.teleopMid[i],
-                          ),
-                          HybridEnumChip(
-                            onPressed: updateLow,
-                            selection: appState.teleopLow[i],
-                          )
-                        ]);
-            }).toList()),
-      ],
-    ));
+                mainAxisAlignment: MainAxisAlignment.center,
+                // ToggleChip type depends on column number
+                children: [
+                  i % 3 != 1
+                      ? ConeChip(
+                          onPressed: updateHigh,
+                          isSelected: appState.teleopHigh[i],
+                        )
+                      : CubeChip(
+                          onPressed: updateHigh,
+                          isSelected: appState.teleopHigh[i],
+                        ),
+                  i % 3 != 1
+                      ? ConeChip(
+                          onPressed: updateMid,
+                          isSelected: appState.teleopMid[i],
+                        )
+                      : CubeChip(
+                          onPressed: updateMid,
+                          isSelected: appState.teleopMid[i],
+                        ),
+                  HybridChip(
+                    onPressed: updateLow,
+                    selection: appState.teleopLow[i],
+                  )
+                ],
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/pages/teleop.dart
+++ b/lib/pages/teleop.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../main.dart';
+import '../widgets/enum_chip.dart';
 import '../widgets/toggle_chip.dart';
 import '../widgets/scoring_legend.dart';
 
@@ -12,712 +13,94 @@ class TeleopPage extends StatefulWidget {
   State<TeleopPage> createState() => _TeleopPageState();
 }
 
-enum TeleopHigh1 { none, cone }
-
-enum TeleopHigh2 { none, cube }
-
-enum TeleopHigh3 { none, cone }
-
-enum TeleopHigh4 { none, cone }
-
-enum TeleopHigh5 { none, cube }
-
-enum TeleopHigh6 { none, cone }
-
-enum TeleopHigh7 { none, cone }
-
-enum TeleopHigh8 { none, cube }
-
-enum TeleopHigh9 { none, cone }
-
-enum TeleopMid1 { none, cone }
-
-enum TeleopMid2 { none, cube }
-
-enum TeleopMid3 { none, cone }
-
-enum TeleopMid4 { none, cone }
-
-enum TeleopMid5 { none, cube }
-
-enum TeleopMid6 { none, cone }
-
-enum TeleopMid7 { none, cone }
-
-enum TeleopMid8 { none, cube }
-
-enum TeleopMid9 { none, cone }
-
-enum TeleopLow1 { none, cone, cube }
-
-enum TeleopLow2 { none, cone, cube }
-
-enum TeleopLow3 { none, cone, cube }
-
-enum TeleopLow4 { none, cone, cube }
-
-enum TeleopLow5 { none, cone, cube }
-
-enum TeleopLow6 { none, cone, cube }
-
-enum TeleopLow7 { none, cone, cube }
-
-enum TeleopLow8 { none, cone, cube }
-
-enum TeleopLow9 { none, cone, cube }
-
-enum Defence { no, yes }
-
-enum GroundIntake { no, yes }
-
-enum SingleSubstationIntake { no, yes }
-
-enum DoubleSubstationIntake { no, yes }
-
 class _TeleopPageState extends State<TeleopPage> {
   @override
   Widget build(BuildContext context) {
     var appState = context.watch<MyAppState>();
-    void updateTeleopHigh1(TeleopHigh1 value) {
-      setState(() {
-        if (appState.teleopHigh1 == value) {
-          appState.teleopHigh1 = TeleopHigh1.none;
-        } else {
-          appState.teleopHigh1 = value;
-        }
-      });
-    }
-
-    void updateTeleopHigh2(TeleopHigh2 value) {
-      setState(() {
-        if (appState.teleopHigh2 == value) {
-          appState.teleopHigh2 = TeleopHigh2.none;
-        } else {
-          appState.teleopHigh2 = value;
-        }
-      });
-    }
-
-    void updateTeleopHigh3(TeleopHigh3 value) {
-      setState(() {
-        if (appState.teleopHigh3 == value) {
-          appState.teleopHigh3 = TeleopHigh3.none;
-        } else {
-          appState.teleopHigh3 = value;
-        }
-      });
-    }
-
-    void updateTeleopHigh4(TeleopHigh4 value) {
-      setState(() {
-        if (appState.teleopHigh4 == value) {
-          appState.teleopHigh4 = TeleopHigh4.none;
-        } else {
-          appState.teleopHigh4 = value;
-        }
-      });
-    }
-
-    void updateTeleopHigh5(TeleopHigh5 value) {
-      setState(() {
-        if (appState.teleopHigh5 == value) {
-          appState.teleopHigh5 = TeleopHigh5.none;
-        } else {
-          appState.teleopHigh5 = value;
-        }
-      });
-    }
-
-    void updateTeleopHigh6(TeleopHigh6 value) {
-      setState(() {
-        if (appState.teleopHigh6 == value) {
-          appState.teleopHigh6 = TeleopHigh6.none;
-        } else {
-          appState.teleopHigh6 = value;
-        }
-      });
-    }
-
-    void updateTeleopHigh7(TeleopHigh7 value) {
-      setState(() {
-        if (appState.teleopHigh7 == value) {
-          appState.teleopHigh7 = TeleopHigh7.none;
-        } else {
-          appState.teleopHigh7 = value;
-        }
-      });
-    }
-
-    void updateTeleopHigh8(TeleopHigh8 value) {
-      setState(() {
-        if (appState.teleopHigh8 == value) {
-          appState.teleopHigh8 = TeleopHigh8.none;
-        } else {
-          appState.teleopHigh8 = value;
-        }
-      });
-    }
-
-    void updateTeleopHigh9(TeleopHigh9 value) {
-      setState(() {
-        if (appState.teleopHigh9 == value) {
-          appState.teleopHigh9 = TeleopHigh9.none;
-        } else {
-          appState.teleopHigh9 = value;
-        }
-      });
-    }
-
-    void updateTeleopMid1(TeleopMid1 value) {
-      setState(() {
-        if (appState.teleopMid1 == value) {
-          appState.teleopMid1 = TeleopMid1.none;
-        } else {
-          appState.teleopMid1 = value;
-        }
-      });
-    }
-
-    void updateTeleopMid2(TeleopMid2 value) {
-      setState(() {
-        if (appState.teleopMid2 == value) {
-          appState.teleopMid2 = TeleopMid2.none;
-        } else {
-          appState.teleopMid2 = value;
-        }
-      });
-    }
-
-    void updateTeleopMid3(TeleopMid3 value) {
-      setState(() {
-        if (appState.teleopMid3 == value) {
-          appState.teleopMid3 = TeleopMid3.none;
-        } else {
-          appState.teleopMid3 = value;
-        }
-      });
-    }
-
-    void updateTeleopMid4(TeleopMid4 value) {
-      setState(() {
-        if (appState.teleopMid4 == value) {
-          appState.teleopMid4 = TeleopMid4.none;
-        } else {
-          appState.teleopMid4 = value;
-        }
-      });
-    }
-
-    void updateTeleopMid5(TeleopMid5 value) {
-      setState(() {
-        if (appState.teleopMid5 == value) {
-          appState.teleopMid5 = TeleopMid5.none;
-        } else {
-          appState.teleopMid5 = value;
-        }
-      });
-    }
-
-    void updateTeleopMid6(TeleopMid6 value) {
-      setState(() {
-        if (appState.teleopMid6 == value) {
-          appState.teleopMid6 = TeleopMid6.none;
-        } else {
-          appState.teleopMid6 = value;
-        }
-      });
-    }
-
-    void updateTeleopMid7(TeleopMid7 value) {
-      setState(() {
-        if (appState.teleopMid7 == value) {
-          appState.teleopMid7 = TeleopMid7.none;
-        } else {
-          appState.teleopMid7 = value;
-        }
-      });
-    }
-
-    void updateTeleopMid8(TeleopMid8 value) {
-      setState(() {
-        if (appState.teleopMid8 == value) {
-          appState.teleopMid8 = TeleopMid8.none;
-        } else {
-          appState.teleopMid8 = value;
-        }
-      });
-    }
-
-    void updateTeleopMid9(TeleopMid9 value) {
-      setState(() {
-        if (appState.teleopMid9 == value) {
-          appState.teleopMid9 = TeleopMid9.none;
-        } else {
-          appState.teleopMid9 = value;
-        }
-      });
-    }
-
-    void updateTeleopLow1(TeleopLow1 value) {
-      setState(() {
-        if (appState.teleopLow1 == value) {
-          appState.teleopLow1 = TeleopLow1.none;
-        } else {
-          appState.teleopLow1 = value;
-        }
-      });
-    }
-
-    void updateTeleopLow2(TeleopLow2 value) {
-      setState(() {
-        if (appState.teleopLow2 == value) {
-          appState.teleopLow2 = TeleopLow2.none;
-        } else {
-          appState.teleopLow2 = value;
-        }
-      });
-    }
-
-    void updateTeleopLow3(TeleopLow3 value) {
-      setState(() {
-        if (appState.teleopLow3 == value) {
-          appState.teleopLow3 = TeleopLow3.none;
-        } else {
-          appState.teleopLow3 = value;
-        }
-      });
-    }
-
-    void updateTeleopLow4(TeleopLow4 value) {
-      setState(() {
-        if (appState.teleopLow4 == value) {
-          appState.teleopLow4 = TeleopLow4.none;
-        } else {
-          appState.teleopLow4 = value;
-        }
-      });
-    }
-
-    void updateTeleopLow5(TeleopLow5 value) {
-      setState(() {
-        if (appState.teleopLow5 == value) {
-          appState.teleopLow5 = TeleopLow5.none;
-        } else {
-          appState.teleopLow5 = value;
-        }
-      });
-    }
-
-    void updateTeleopLow6(TeleopLow6 value) {
-      setState(() {
-        if (appState.teleopLow6 == value) {
-          appState.teleopLow6 = TeleopLow6.none;
-        } else {
-          appState.teleopLow6 = value;
-        }
-      });
-    }
-
-    void updateTeleopLow7(TeleopLow7 value) {
-      setState(() {
-        if (appState.teleopLow7 == value) {
-          appState.teleopLow7 = TeleopLow7.none;
-        } else {
-          appState.teleopLow7 = value;
-        }
-      });
-    }
-
-    void updateTeleopLow8(TeleopLow8 value) {
-      setState(() {
-        if (appState.teleopLow8 == value) {
-          appState.teleopLow8 = TeleopLow8.none;
-        } else {
-          appState.teleopLow8 = value;
-        }
-      });
-    }
-
-    void updateTeleopLow9(TeleopLow9 value) {
-      setState(() {
-        if (appState.teleopLow9 == value) {
-          appState.teleopLow9 = TeleopLow9.none;
-        } else {
-          appState.teleopLow9 = value;
-        }
-      });
-    }
-
-    void updateDefence(Defence value) {
-      setState(() {
-        if (appState.defence == value) {
-          appState.defence = Defence.no;
-        } else {
-          appState.defence = value;
-        }
-      });
-    }
-
-    void updateGroundIntake(GroundIntake value) {
-      setState(() {
-        if (appState.groundIntake == value) {
-          appState.groundIntake = GroundIntake.no;
-        } else {
-          appState.groundIntake = value;
-        }
-      });
-    }
-
-    void updateSingleSubstationIntake(SingleSubstationIntake value) {
-      setState(() {
-        if (appState.singleSubstationIntake == value) {
-          appState.singleSubstationIntake = SingleSubstationIntake.no;
-        } else {
-          appState.singleSubstationIntake = value;
-        }
-      });
-    }
-
-    void updateDoubleSubstationIntake(DoubleSubstationIntake value) {
-      setState(() {
-        if (appState.doubleSubstationIntake == value) {
-          appState.doubleSubstationIntake = DoubleSubstationIntake.no;
-        } else {
-          appState.doubleSubstationIntake = value;
-        }
-      });
-    }
 
     return Center(
-      child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            ToggleChip(
-                text: "Defence",
-                onPressed: updateDefence,
-                value: Defence.yes,
-                selection: appState.defence,
-                icon1: Icons.circle,
-                icon2: Icons.circle_outlined),
-            const SizedBox(height: 8),
-            const Text("Robot intake position:"),
-            Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-              ToggleChip(
-                  text: "Ground",
-                  onPressed: updateGroundIntake,
-                  value: GroundIntake.yes,
-                  selection: appState.groundIntake,
-                  icon1: Icons.circle,
-                  icon2: Icons.circle_outlined),
-              ToggleChip(
-                  text: "Single substation",
-                  onPressed: updateSingleSubstationIntake,
-                  value: SingleSubstationIntake.yes,
-                  selection: appState.singleSubstationIntake,
-                  icon1: Icons.circle,
-                  icon2: Icons.circle_outlined),
-              ToggleChip(
-                  text: "Double substation",
-                  onPressed: updateDoubleSubstationIntake,
-                  value: DoubleSubstationIntake.yes,
-                  selection: appState.doubleSubstationIntake,
-                  icon1: Icons.circle,
-                  icon2: Icons.circle_outlined),
-            ]),
-            const SizedBox(height: 8),
-            const ScoringLegend(),
-            const Text("Teleop Pieces Scored:"),
-            Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-              Column(
+        child: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        CircleToggleChip(
+          text: "Defence",
+          onPressed: (value) => setState(() => appState.defense = value),
+          isSelected: appState.defense,
+        ),
+        const SizedBox(height: 8),
+        const Text("Robot intake position:"),
+        Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
+          CircleToggleChip(
+            text: "Ground",
+            onPressed: (value) => setState(() => appState.groundIntake = value),
+            isSelected: appState.groundIntake,
+          ),
+          CircleToggleChip(
+            text: "Single substation",
+            onPressed: (value) =>
+                setState(() => appState.singleSubstationIntake = value),
+            isSelected: appState.singleSubstationIntake,
+          ),
+          CircleToggleChip(
+            text: "Double substation",
+            onPressed: (value) =>
+                setState(() => appState.doubleSubstationIntake = value),
+            isSelected: appState.doubleSubstationIntake,
+          ),
+        ]),
+        const SizedBox(height: 8),
+        const ScoringLegend(),
+        const Text("Teleop Pieces Scored:"),
+        Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            // acts like another build function, but for each column
+            children: List.generate(9, (i) => i).map((i) {
+              void updateHigh(value) {
+                setState(() => appState.teleopHigh[i] = value);
+              }
+
+              void updateMid(value) {
+                setState(() => appState.teleopMid[i] = value);
+              }
+
+              void updateLow(value) {
+                setState(() => appState.teleopLow[i] = value);
+              }
+
+              return Column(
                   mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopHigh1,
-                        value: TeleopHigh1.cone,
-                        selection: appState.teleopHigh1,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopMid1,
-                        value: TeleopMid1.cone,
-                        selection: appState.teleopMid1,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow1,
-                        value: TeleopLow1.cone,
-                        selection: appState.teleopLow1,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow1,
-                        value: TeleopLow1.cube,
-                        selection: appState.teleopLow1,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                  ]),
-              Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopHigh2,
-                        value: TeleopHigh2.cube,
-                        selection: appState.teleopHigh2,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopMid2,
-                        value: TeleopMid2.cube,
-                        selection: appState.teleopMid2,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow2,
-                        value: TeleopLow2.cone,
-                        selection: appState.teleopLow2,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow2,
-                        value: TeleopLow2.cube,
-                        selection: appState.teleopLow2,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                  ]),
-              Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopHigh3,
-                        value: TeleopHigh3.cone,
-                        selection: appState.teleopHigh3,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopMid3,
-                        value: TeleopMid3.cone,
-                        selection: appState.teleopMid3,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow3,
-                        value: TeleopLow3.cone,
-                        selection: appState.teleopLow3,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow3,
-                        value: TeleopLow3.cube,
-                        selection: appState.teleopLow3,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                  ]),
-              Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopHigh4,
-                        value: TeleopHigh4.cone,
-                        selection: appState.teleopHigh4,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopMid4,
-                        value: TeleopMid4.cone,
-                        selection: appState.teleopMid4,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow4,
-                        value: TeleopLow4.cone,
-                        selection: appState.teleopLow4,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow4,
-                        value: TeleopLow4.cube,
-                        selection: appState.teleopLow4,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                  ]),
-              Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopHigh5,
-                        value: TeleopHigh5.cube,
-                        selection: appState.teleopHigh5,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopMid5,
-                        value: TeleopMid5.cube,
-                        selection: appState.teleopMid5,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow5,
-                        value: TeleopLow5.cone,
-                        selection: appState.teleopLow5,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow5,
-                        value: TeleopLow5.cube,
-                        selection: appState.teleopLow5,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                  ]),
-              Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopHigh6,
-                        value: TeleopHigh6.cone,
-                        selection: appState.teleopHigh6,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopMid6,
-                        value: TeleopMid6.cone,
-                        selection: appState.teleopMid6,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow6,
-                        value: TeleopLow6.cone,
-                        selection: appState.teleopLow6,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow6,
-                        value: TeleopLow6.cube,
-                        selection: appState.teleopLow6,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                  ]),
-              Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopHigh7,
-                        value: TeleopHigh7.cone,
-                        selection: appState.teleopHigh7,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopMid7,
-                        value: TeleopMid7.cone,
-                        selection: appState.teleopMid7,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow7,
-                        value: TeleopLow7.cone,
-                        selection: appState.teleopLow7,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow7,
-                        value: TeleopLow7.cube,
-                        selection: appState.teleopLow7,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                  ]),
-              Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopHigh8,
-                        value: TeleopHigh8.cube,
-                        selection: appState.teleopHigh8,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopMid8,
-                        value: TeleopMid8.cube,
-                        selection: appState.teleopMid8,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow8,
-                        value: TeleopLow8.cone,
-                        selection: appState.teleopLow8,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow8,
-                        value: TeleopLow8.cube,
-                        selection: appState.teleopLow8,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                  ]),
-              Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopHigh9,
-                        value: TeleopHigh9.cone,
-                        selection: appState.teleopHigh9,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopMid9,
-                        value: TeleopMid9.cone,
-                        selection: appState.teleopMid9,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow9,
-                        value: TeleopLow9.cone,
-                        selection: appState.teleopLow9,
-                        icon1: Icons.adobe,
-                        icon2: Icons.change_history),
-                    ToggleChip(
-                        text: "",
-                        onPressed: updateTeleopLow9,
-                        value: TeleopLow9.cube,
-                        selection: appState.teleopLow9,
-                        icon1: Icons.square,
-                        icon2: Icons.square_outlined),
-                  ]),
-            ])
-          ]),
-    );
+                  // ToggleChip type depends on column number
+                  children: i % 3 != 1
+                      ? [
+                          ConeToggleChip(
+                            onPressed: updateHigh,
+                            isSelected: appState.teleopHigh[i],
+                          ),
+                          ConeToggleChip(
+                            onPressed: updateMid,
+                            isSelected: appState.teleopMid[i],
+                          ),
+                          HybridEnumChip(
+                            onPressed: updateLow,
+                            selection: appState.teleopLow[i],
+                          )
+                        ]
+                      : [
+                          CubeToggleChip(
+                            onPressed: updateHigh,
+                            isSelected: appState.teleopHigh[i],
+                          ),
+                          CubeToggleChip(
+                            onPressed: updateMid,
+                            isSelected: appState.teleopMid[i],
+                          ),
+                          HybridEnumChip(
+                            onPressed: updateLow,
+                            selection: appState.teleopLow[i],
+                          )
+                        ]);
+            }).toList()),
+      ],
+    ));
   }
 }

--- a/lib/widgets/enum_chip.dart
+++ b/lib/widgets/enum_chip.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+
+class EnumChip extends StatelessWidget {
+  final Function onPressed;
+  final String text;
+  final Enum selection;
+  final Enum? none;
+  final Enum value;
+  final IconData active;
+  final IconData inactive;
+
+  const EnumChip({
+    super.key,
+    required this.onPressed,
+    required this.text,
+    required this.selection,
+    required this.value,
+    required this.active,
+    required this.inactive,
+    this.none,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(5.0),
+      child: text != ""
+          ? ElevatedButton.icon(
+              onPressed: () => selection == value && none != null
+                  ? onPressed(none)
+                  : onPressed(value),
+              icon: Icon(selection == value ? active : inactive),
+              label: Text(text),
+            )
+          : IconButton(
+              onPressed: () => selection == value && none != null
+                  ? onPressed(none)
+                  : onPressed(value),
+              icon: Icon(selection == value ? active : inactive),
+            ),
+    );
+  }
+}
+
+class CircleEnumChip extends StatelessWidget {
+  final Function onPressed;
+  final String text;
+  final Enum selection;
+  final Enum? none;
+  final Enum value;
+
+  const CircleEnumChip({
+    super.key,
+    required this.onPressed,
+    required this.text,
+    required this.selection,
+    required this.value,
+    this.none,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return EnumChip(
+      onPressed: onPressed,
+      text: text,
+      selection: selection,
+      value: value,
+      none: none,
+      active: Icons.circle,
+      inactive: Icons.circle_outlined,
+    );
+  }
+}
+
+class HybridEnumChip extends StatelessWidget {
+  final Function onPressed;
+  final Enum selection;
+
+  const HybridEnumChip({
+    super.key,
+    required this.onPressed,
+    required this.selection,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(15),
+          border: Border.all(color: Colors.white)),
+      child: Column(
+        children: [
+          EnumChip(
+            onPressed: onPressed,
+            text: "",
+            selection: selection,
+            value: Piece.cone,
+            none: Piece.none,
+            active: Icons.adobe,
+            inactive: Icons.change_history,
+          ),
+          EnumChip(
+            onPressed: onPressed,
+            text: "",
+            selection: selection,
+            value: Piece.cube,
+            none: Piece.none,
+            active: Icons.square,
+            inactive: Icons.square_outlined,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/enum_chip.dart
+++ b/lib/widgets/enum_chip.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../main.dart';
 
-class EnumChip extends StatelessWidget {
+class BaseEnumChip extends StatelessWidget {
   final Function onPressed;
   final String text;
   final Enum selection;
@@ -11,7 +11,7 @@ class EnumChip extends StatelessWidget {
   final IconData active;
   final IconData inactive;
 
-  const EnumChip({
+  const BaseEnumChip({
     super.key,
     required this.onPressed,
     required this.text,
@@ -44,14 +44,14 @@ class EnumChip extends StatelessWidget {
   }
 }
 
-class CircleEnumChip extends StatelessWidget {
+class EnumChip extends StatelessWidget {
   final Function onPressed;
   final String text;
   final Enum selection;
   final Enum? none;
   final Enum value;
 
-  const CircleEnumChip({
+  const EnumChip({
     super.key,
     required this.onPressed,
     required this.text,
@@ -62,7 +62,7 @@ class CircleEnumChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return EnumChip(
+    return BaseEnumChip(
       onPressed: onPressed,
       text: text,
       selection: selection,
@@ -74,11 +74,11 @@ class CircleEnumChip extends StatelessWidget {
   }
 }
 
-class HybridEnumChip extends StatelessWidget {
+class HybridChip extends StatelessWidget {
   final Function onPressed;
   final Enum selection;
 
-  const HybridEnumChip({
+  const HybridChip({
     super.key,
     required this.onPressed,
     required this.selection,
@@ -92,7 +92,7 @@ class HybridEnumChip extends StatelessWidget {
           border: Border.all(color: Colors.white)),
       child: Column(
         children: [
-          EnumChip(
+          BaseEnumChip(
             onPressed: onPressed,
             text: "",
             selection: selection,
@@ -101,7 +101,7 @@ class HybridEnumChip extends StatelessWidget {
             active: Icons.adobe,
             inactive: Icons.change_history,
           ),
-          EnumChip(
+          BaseEnumChip(
             onPressed: onPressed,
             text: "",
             selection: selection,

--- a/lib/widgets/scoring_legend.dart
+++ b/lib/widgets/scoring_legend.dart
@@ -6,40 +6,41 @@ class ScoringLegend extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          const Text("Scoring Key:"),
-          Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-            Padding(
-                padding: const EdgeInsets.all(5.0),
-                child: ElevatedButton.icon(
-                    onPressed: () {},
-                    icon: const Icon(Icons.change_history),
-                    label: const Text("Cone: not selected"))),
-            Padding(
-                padding: const EdgeInsets.all(5.0),
-                child: ElevatedButton.icon(
-                    onPressed: () {},
-                    icon: const Icon(Icons.adobe),
-                    label: const Text("Cone: selected"))),
-          ]),
-          Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
-            Padding(
-                padding: const EdgeInsets.all(5.0),
-                child: ElevatedButton.icon(
-                    onPressed: () {},
-                    icon: const Icon(Icons.square_outlined),
-                    label: const Text("Cube: not selected"))),
-            Padding(
-                padding: const EdgeInsets.all(5.0),
-                child: ElevatedButton.icon(
-                    onPressed: () {},
-                    icon: const Icon(Icons.square),
-                    label: const Text("Cube: selected"))),
-          ]),
-          const SizedBox(
-            height: 8,
-          )
-        ]);
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        const Text("Scoring Key:"),
+        Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
+          Padding(
+              padding: const EdgeInsets.all(5.0),
+              child: ElevatedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.change_history),
+                  label: const Text("Cone: not selected"))),
+          Padding(
+              padding: const EdgeInsets.all(5.0),
+              child: ElevatedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.adobe),
+                  label: const Text("Cone: selected"))),
+        ]),
+        Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
+          Padding(
+              padding: const EdgeInsets.all(5.0),
+              child: ElevatedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.square_outlined),
+                  label: const Text("Cube: not selected"))),
+          Padding(
+              padding: const EdgeInsets.all(5.0),
+              child: ElevatedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.square),
+                  label: const Text("Cube: selected"))),
+        ]),
+        const SizedBox(
+          height: 8,
+        )
+      ],
+    );
   }
 }

--- a/lib/widgets/toggle_chip.dart
+++ b/lib/widgets/toggle_chip.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
-class ToggleChip extends StatelessWidget {
+class BaseToggleChip extends StatelessWidget {
   final Function onPressed;
   final String text;
   final bool isSelected;
   final IconData active;
   final IconData inactive;
 
-  const ToggleChip({
+  const BaseToggleChip({
     super.key,
     required this.onPressed,
     required this.isSelected,
@@ -34,12 +34,12 @@ class ToggleChip extends StatelessWidget {
   }
 }
 
-class CircleToggleChip extends StatelessWidget {
+class ToggleChip extends StatelessWidget {
   final Function onPressed;
   final String text;
   final bool isSelected;
 
-  const CircleToggleChip({
+  const ToggleChip({
     super.key,
     required this.onPressed,
     required this.isSelected,
@@ -48,7 +48,7 @@ class CircleToggleChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ToggleChip(
+    return BaseToggleChip(
       onPressed: onPressed,
       isSelected: isSelected,
       text: text,
@@ -58,11 +58,11 @@ class CircleToggleChip extends StatelessWidget {
   }
 }
 
-class ConeToggleChip extends StatelessWidget {
+class ConeChip extends StatelessWidget {
   final Function onPressed;
   final bool isSelected;
 
-  const ConeToggleChip({
+  const ConeChip({
     super.key,
     required this.onPressed,
     required this.isSelected,
@@ -70,7 +70,7 @@ class ConeToggleChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ToggleChip(
+    return BaseToggleChip(
       onPressed: onPressed,
       isSelected: isSelected,
       text: "",
@@ -80,11 +80,11 @@ class ConeToggleChip extends StatelessWidget {
   }
 }
 
-class CubeToggleChip extends StatelessWidget {
+class CubeChip extends StatelessWidget {
   final Function onPressed;
   final bool isSelected;
 
-  const CubeToggleChip({
+  const CubeChip({
     super.key,
     required this.onPressed,
     required this.isSelected,
@@ -92,7 +92,7 @@ class CubeToggleChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ToggleChip(
+    return BaseToggleChip(
       onPressed: onPressed,
       isSelected: isSelected,
       text: "",

--- a/lib/widgets/toggle_chip.dart
+++ b/lib/widgets/toggle_chip.dart
@@ -3,30 +3,101 @@ import 'package:flutter/material.dart';
 class ToggleChip extends StatelessWidget {
   final Function onPressed;
   final String text;
-  final Enum selection;
-  final Enum value;
-  final IconData icon1;
-  final IconData icon2;
+  final bool isSelected;
+  final IconData active;
+  final IconData inactive;
 
   const ToggleChip({
     super.key,
     required this.onPressed,
+    required this.isSelected,
+    required this.active,
+    required this.inactive,
     required this.text,
-    required this.selection,
-    required this.value,
-    required this.icon1,
-    required this.icon2,
   });
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(5.0),
-      child: ElevatedButton.icon(
-        onPressed: () => onPressed(value),
-        icon: Icon(selection == value ? icon1 : icon2),
-        label: Text(text),
-      ),
+      child: text != ""
+          ? ElevatedButton.icon(
+              onPressed: () => onPressed(!isSelected),
+              icon: Icon(isSelected ? active : inactive),
+              label: Text(text),
+            )
+          : IconButton(
+              onPressed: () => onPressed(!isSelected),
+              icon: Icon(isSelected ? active : inactive),
+            ),
+    );
+  }
+}
+
+class CircleToggleChip extends StatelessWidget {
+  final Function onPressed;
+  final String text;
+  final bool isSelected;
+
+  const CircleToggleChip({
+    super.key,
+    required this.onPressed,
+    required this.isSelected,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ToggleChip(
+      onPressed: onPressed,
+      isSelected: isSelected,
+      text: text,
+      active: Icons.circle,
+      inactive: Icons.circle_outlined,
+    );
+  }
+}
+
+class ConeToggleChip extends StatelessWidget {
+  final Function onPressed;
+  final bool isSelected;
+
+  const ConeToggleChip({
+    super.key,
+    required this.onPressed,
+    required this.isSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ToggleChip(
+      onPressed: onPressed,
+      isSelected: isSelected,
+      text: "",
+      active: Icons.adobe,
+      inactive: Icons.change_history,
+    );
+  }
+}
+
+class CubeToggleChip extends StatelessWidget {
+  final Function onPressed;
+  final bool isSelected;
+
+  const CubeToggleChip({
+    super.key,
+    required this.onPressed,
+    required this.isSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ToggleChip(
+      onPressed: onPressed,
+      isSelected: isSelected,
+      text: "",
+      active: Icons.square,
+      inactive: Icons.square_outlined,
     );
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,6 @@
 import FlutterMacOS
 import Foundation
 
-import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,72 +5,63 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.10.0"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.4"
   flutter:
@@ -82,8 +73,7 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -100,168 +90,147 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.4"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
   nested:
     dependency: transitive
     description:
       name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: "2e32f1640f07caef0d3cb993680f181c79e54a3827b997d5ee221490d131fbd9"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.8"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: f0abc8ebd7253741f05488b4813d936b4d07c6bae3e86148a09e342ee4b08e76
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: bcabbe399d4042b8ee687e17548d5d3f527255253b4a639f5f8d2094a9c2b45c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: dbf0f707c78beedc9200146ad3cb0ab4d5da13c246336987be6940f026500d3a
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
   process:
     dependency: transitive
     description:
       name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.2.4"
   provider:
     dependency: "direct main"
     description:
       name: provider
-      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "6.0.5"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "5949029e70abe87f75cfe59d17bf5c397619c4b74a099b10116baeb34786fad9"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.17"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "955e9736a12ba776bdd261cf030232b30eadfcd9c79b32a3250dd4a494e8c8f7"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.15"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "2b55c18636a4edc529fa5cd44c03d3f3100c00513f518c5127c951978efcccd0"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      sha256: f8ea038aa6da37090093974ebdcf4397010605fd2ff65c37a66f9d28394cb874
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: da9431745ede5ece47bc26d5d73a9d3c6936ef6945c101a5aca46f62e52c1cf3
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: a4b5bc37fe1b368bbc81f953197d55e12f49d0296e7e412dfe2d2d77d6929958
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.4"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      sha256: "5eaf05ae77658d3521d0e993ede1af962d4b326cd2153d312df716dc250f00c9"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
   sky_engine:
@@ -273,72 +242,63 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: c9ebe7ee4ab0c2194e65d3a07d8c54c5d00bb001b76081c4a04cdb8448b59e46
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
 sdks:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,65 +5,58 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
-  ffi:
-    dependency: transitive
-    description:
-      name: ffi
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.1"
-  file:
-    dependency: transitive
-    description:
-      name: file
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "6.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,7 +66,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -81,158 +75,70 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_plugins:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   nested:
     dependency: transitive
     description:
       name: nested
-      url: "https://pub.dartlang.org"
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
-  path_provider_linux:
-    dependency: transitive
-    description:
-      name: path_provider_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.8"
-  path_provider_platform_interface:
-    dependency: transitive
-    description:
-      name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.5"
-  path_provider_windows:
-    dependency: transitive
-    description:
-      name: path_provider_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
-  platform:
-    dependency: transitive
-    description:
-      name: platform
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.1.0"
-  plugin_platform_interface:
-    dependency: transitive
-    description:
-      name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.2.4"
   provider:
     dependency: "direct main"
     description:
       name: provider
-      url: "https://pub.dartlang.org"
+      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.5"
-  shared_preferences:
-    dependency: "direct main"
-    description:
-      name: shared_preferences
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.17"
-  shared_preferences_android:
-    dependency: transitive
-    description:
-      name: shared_preferences_android
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.15"
-  shared_preferences_foundation:
-    dependency: transitive
-    description:
-      name: shared_preferences_foundation
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
-  shared_preferences_linux:
-    dependency: transitive
-    description:
-      name: shared_preferences_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
-  shared_preferences_platform_interface:
-    dependency: transitive
-    description:
-      name: shared_preferences_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.0"
-  shared_preferences_web:
-    dependency: transitive
-    description:
-      name: shared_preferences_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.4"
-  shared_preferences_windows:
-    dependency: transitive
-    description:
-      name: shared_preferences_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -242,65 +148,58 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.1.3"
-  xdg_directories:
-    dependency: transitive
-    description:
-      name: xdg_directories
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
+    version: "2.1.4"
 sdks:
   dart: ">=2.18.2 <3.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=1.16.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
     sdk: flutter
   
   provider: ^6.0.0
-  shared_preferences: ^2.0.17
+  # shared_preferences: ^2.0.17
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
- Delete many redundant enums.
- Rewrite the Change Notifier to use arrays instead of individual named variables.
- Connect all pages' data to the Change Notifier, and remove the shared preference code (the change notifier already stores it all in once place.
- Write custom widgets for the different types of chips (Toggle, Cone, Cube, Hybrid).
- Replace repetitious Columns with a single looping column.
- Removed the pesky trailing space on the icon chips (they look worse for now, but that can be fixed, and they're symmetrical)